### PR TITLE
Add optional license_model to the db module

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -21,6 +21,7 @@ resource "aws_db_instance" "db" {
   storage_type            = "${var.storage_type}"
   apply_immediately       = "${var.apply_immediately}"
   skip_final_snapshot     = "${var.skip_final_snapshot}"
+  license_model           = "${var.license_model}"
 }
 
 resource "aws_security_group" "db_sg" {

--- a/modules/database/vars.tf
+++ b/modules/database/vars.tf
@@ -18,3 +18,4 @@ variable "allocated_storage" {}
 variable "storage_type" {}
 variable "apply_immediately" {}
 variable "skip_final_snapshot" { default = "false" }
+variable "license_model" { default = "" }


### PR DESCRIPTION
Eftersom vi er så "heldige" å må bruke M$ SQL Server, så må vi kunne sende med `license_model` til DB modulen.. :)