### PR TITLE
lambda-vpc-role

### DIFF
--- a/modules/lambda_vpc_role/main.tf
+++ b/modules/lambda_vpc_role/main.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_role" "role" {
+  name = "${var.role_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "lambda.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "policy" {
+  count       = "${length(var.policy_templates)}"
+  name        = "${element(var.policy_names, count.index)}"
+  description = "${element(var.policy_descriptions, count.index)}"
+  policy      = "${element(var.policy_templates, count.index)}"
+}
+
+resource "aws_iam_role_policy_attachment" "policy-attach" {
+  count      = "${length(var.policy_templates)}"
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "${element(aws_iam_policy.policy.*.arn, count.index)}"
+}
+
+resource "aws_iam_role_policy_attachment" "default-policy-attach" {
+  role       = "${aws_iam_role.role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}

--- a/modules/lambda_vpc_role/outputs.tf
+++ b/modules/lambda_vpc_role/outputs.tf
@@ -1,0 +1,3 @@
+output "arn" {
+  value = "${aws_iam_role.role.arn}"
+}

--- a/modules/lambda_vpc_role/vars.tf
+++ b/modules/lambda_vpc_role/vars.tf
@@ -1,0 +1,10 @@
+variable "role_name" {}
+variable "policy_templates" {
+  type = "list"
+}
+variable "policy_names" {
+  type = "list"
+}
+variable "policy_descriptions" {
+  type = "list"
+}


### PR DESCRIPTION
Created lambda_vpc_role which creates an iam role for lambda with AWSLambdaVPCAccessExecutionRole as the default policy. Additional policies can be provided through input variables.