### PR TITLE
Add access to Cloudwatch metrics to EBS instances

### DIFF
--- a/modules/instance_profile/main.tf
+++ b/modules/instance_profile/main.tf
@@ -22,6 +22,23 @@ resource "aws_iam_role" "instance_profile_role" {
 EOF
 }
 
+resource "aws_iam_policy" "cloudwatch_metric_policy" {
+  name        = "${var.instance_profile_name}-cloudwatch-metric-policy"
+  description = "Provides write access to Cloudwatch metrics"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "cloudwatch:PutMetricData",
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy_attachment" "webtier_policy_attachment" {
   role       = "${aws_iam_instance_profile.instance_profile.name}"
   policy_arn = "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier"
@@ -30,4 +47,9 @@ resource "aws_iam_role_policy_attachment" "webtier_policy_attachment" {
 resource "aws_iam_role_policy_attachment" "cloudwatch_policy_attachment" {
   role       = "${aws_iam_instance_profile.instance_profile.name}"
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_metric_policy_attachment" {
+  role       = "${aws_iam_instance_profile.instance_profile.name}"
+  policy_arn = "${aws_iam_policy.cloudwatch_metric_policy.arn}"
 }


### PR DESCRIPTION
A policy that allows Elastic Beanstalk instances to send metrics to Cloudwatch. 

This PR is part of a larger change where we will use an instance profile to access Cloudwatch rather than a IAM User.