### PR TITLE
Update cdn origin s3 bucket policy

### DIFF
--- a/modules/cdn_origin_s3_bucket/main.tf
+++ b/modules/cdn_origin_s3_bucket/main.tf
@@ -5,8 +5,8 @@ resource "aws_s3_bucket" "cdn_origin_s3_bucket" {
 
 data "aws_iam_policy_document" "cdn_access_s3_content_policy" {
   statement {
-    actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${var.bucket_name}/*"]
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = ["arn:aws:s3:::${var.bucket_name}/*", "arn:aws:s3:::${var.bucket_name}"]
 
     principals {
       identifiers = ["${var.origin_access_id_arn}"]


### PR DESCRIPTION
Enables a 404 error when key not found rather than 403.