### PR TITLE
Disregard tags for S3 based origins

### DIFF
--- a/modules/cdn_origin_s3_bucket/main.tf
+++ b/modules/cdn_origin_s3_bucket/main.tf
@@ -6,6 +6,10 @@ resource "aws_s3_bucket" "cdn_origin_s3_bucket" {
     allowed_methods = ["${var.allowed_methods}"]
     allowed_origins = ["${var.allowed_origins}"]
   }
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }
 
 data "aws_nat_gateway" "test_gateway" {

--- a/modules/dynamodb/main.tf
+++ b/modules/dynamodb/main.tf
@@ -25,6 +25,7 @@ resource "aws_dynamodb_table" "dynamodb-table" {
     ignore_changes = [
       "read_capacity",
       "write_capacity",
+      "ttl",
       "tags",
     ]
   }


### PR DESCRIPTION
Also ignore the ttl attribute from Dynamodb