### PR TITLE
Legge til mulighet for å lage indekser i DynamoDB

### DIFF
--- a/modules/dynamodb/main.tf
+++ b/modules/dynamodb/main.tf
@@ -11,9 +11,12 @@ resource "aws_dynamodb_table" "dynamodb-table" {
     attribute_name = var.ttl_attribute_name
   }
 
-  attribute {
-    name = var.hash_key
-    type = "S"
+  dynamic "attribute" {
+    for_each = var.attributes
+    content {
+      name = attribute.value.hash_key
+      type = attribute.value.type
+    }
   }
 
   tags = {
@@ -36,6 +39,18 @@ resource "aws_dynamodb_table" "dynamodb-table" {
 
   server_side_encryption {
     enabled = var.encryption_enabled
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.indices
+    content {
+      hash_key           = global_secondary_index.value.hash_key
+      name               = global_secondary_index.value.name
+      read_capacity      = 1
+      write_capacity     = 1
+      projection_type    = global_secondary_index.value.projection_type
+      non_key_attributes = global_secondary_index.value.non_key_attributes
+    }
   }
 }
 

--- a/modules/dynamodb/vars.tf
+++ b/modules/dynamodb/vars.tf
@@ -35,3 +35,20 @@ variable "encryption_enabled" {
   default = false
 }
 
+variable "attributes" {
+  type = list(object({
+    hash_key = string,
+    type     = string
+  }))
+}
+
+variable "indices" {
+  type = list(object({
+    hash_key           = string,
+    name               = string,
+    projection_type    = string,
+    non_key_attributes = list(string)
+  }))
+
+  default = []
+}


### PR DESCRIPTION
Foreløpig settes lese- og skrivekapasiteten i indeksene til 1. Kan se på muligheten for å legge til autoskalering etterhvert, men det er ikke førstepri.