### PR TITLE
Change how the root password is handled

### DIFF
--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -5,4 +5,3 @@ output "db_security_group_id" {
 output "address" {
   value = aws_route53_record.db_internal_route53_record.fqdn
 }
-

--- a/modules/database/vars.tf
+++ b/modules/database/vars.tf
@@ -21,9 +21,7 @@ variable "db_instance_class" {
 }
 
 variable "db_username" {
-}
-
-variable "db_password" {
+  default = ""
 }
 
 variable "db_parameter_group_name" {

--- a/modules/database/vars.tf
+++ b/modules/database/vars.tf
@@ -20,10 +20,6 @@ variable "db_engine_version" {
 variable "db_instance_class" {
 }
 
-variable "db_username" {
-  default = ""
-}
-
 variable "db_parameter_group_name" {
 }
 


### PR DESCRIPTION
Instead of passing the root password into the module, it now generates a random string, adds it to Parameter Store for storage and applies it to the database