### PR TITLE
Grant ECR read access to any instance profile.

### DIFF
--- a/modules/ecr-repository/main.tf
+++ b/modules/ecr-repository/main.tf
@@ -2,11 +2,6 @@ resource "aws_ecr_repository" "ecr_repo" {
   name = var.repo_name
 }
 
-resource "aws_ecr_repository_policy" "ecr_policy" {
-  repository = aws_ecr_repository.ecr_repo.id
-  policy     = data.aws_iam_policy_document.ecr_policy_document.json
-}
-
 resource "aws_ecr_lifecycle_policy" "keep_last_N_policy" {
   repository = aws_ecr_repository.ecr_repo.id
 
@@ -25,52 +20,21 @@ resource "aws_ecr_lifecycle_policy" "keep_last_N_policy" {
             "action": {
                 "type": "expire"
             }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Remove untagged images",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 1
+            },
+            "action": {
+                "type": "expire"
+            }
         }
     ]
 }
 EOF
-}
-
-data "aws_iam_instance_profile" "current" {
-  name = var.instance_profile_name
-}
-
-resource "aws_iam_policy" "ecr_access" {
-  name        = "${var.instance_profile_name}-ecr-access"
-  description = "Provides access to login to ECR, which is a requisite for pulling images"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "ecr:GetAuthorizationToken",
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "ecr_access_policy_attachment" {
-  role       = var.instance_profile_name
-  policy_arn = aws_iam_policy.ecr_access.arn
-}
-
-data "aws_iam_policy_document" "ecr_policy_document" {
-  statement {
-    actions = [
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:BatchGetImage",
-      "ecr:GetDownloadUrlForLayer"
-    ]
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        data.aws_iam_instance_profile.current.role_arn
-      ]
-    }
-  }
 }

--- a/modules/ecr-repository/vars.tf
+++ b/modules/ecr-repository/vars.tf
@@ -1,3 +1,2 @@
 variable "repo_name" {}
-variable "instance_profile_name" {}
 variable "images_to_keep" { default = 10 }

--- a/modules/instance_profile/main.tf
+++ b/modules/instance_profile/main.tf
@@ -53,3 +53,11 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_metric_policy_attachment" 
   policy_arn = aws_iam_policy.cloudwatch_metric_policy.arn
 }
 
+data "aws_iam_policy" "ecr_read_only" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read_only" {
+  role       = aws_iam_instance_profile.instance_profile.name
+  policy_arn = data.aws_iam_policy.ecr_read_only.arn
+}


### PR DESCRIPTION
Alt som benytter seg av en instance profile får lesetilgang til ECR repoer.

Gjorde også en liten endring som skal holde ECR repoene litt mer ryddig.

Først implementert i https://github.com/nsbno/form/pull/103
Men fant ut at det var bedre å gjøre noen av de endringene her.