### PR TITLE
Legge til rette for eksterne OAuth2-klienter

### DIFF
--- a/modules/oauth2-client/vars.tf
+++ b/modules/oauth2-client/vars.tf
@@ -4,11 +4,15 @@ variable "env" {}
 
 variable "appname" {}
 
-variable "instance_profile_name" {
+variable "role_name" {
   default = ""
 }
 
 variable "oauth_scopes" {
   type    = list(string)
   default = []
+}
+
+variable "store_credentials" {
+  default = true
 }


### PR DESCRIPTION
Vi trenger ikke å lagre hemmeligheter for eksterne klienter i Secrets Manager.

Henger sammen med [denne PR-en i user](https://github.com/nsbno/user/pull/344).