### PR TITLE
Remove unused 'aws_region' variable from 'route53_cname_record' module

### DIFF
--- a/modules/route53_cname_record/vars.tf
+++ b/modules/route53_cname_record/vars.tf
@@ -1,9 +1,6 @@
 variable "appname" {
 }
 
-variable "aws_region" {
-}
-
 variable "route53_zone" {
 }
 


### PR DESCRIPTION
This will break dependants when upgrading. Simply remove the input variable.
It was never used in the first place, so it should not cause a change.