### PR TITLE
Backup av RDS-instanser til separat konto

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -58,7 +58,8 @@ resource "aws_db_instance" "db" {
   license_model             = var.license_model
 
   tags = {
-    Name = var.db_name_tag
+    Name           = var.db_name_tag
+    CopyDBSnapshot = var.backup_to_other_account ? "True" : "False"
   }
 }
 

--- a/modules/database/vars.tf
+++ b/modules/database/vars.tf
@@ -5,6 +5,11 @@ variable "db_name_tag" {
   default = ""
 }
 
+variable "backup_to_other_account" {
+  type    = bool
+  default = false
+}
+
 variable "db_subnet_group_id" {
 }
 


### PR DESCRIPTION
Vi har fått tilgang til en separat AWS-konto vi kan kopiere backups av databaser til. Jeg har deployet infrastrukturen som er definert [i dette repoet](https://github.com/nsbno/omni-rds-backup) til backup-kontoen og omnikanal-kontoen. Kort oppsummert vil det bli kopiert snapshots av utvalgte RDS-instanser fra omnikanal-kontoen til backup-kontoen. Vi styrer hvilke RDS-instanser vi kopierer over ved å legge til `CopyDBSnapshot=True` som en tag. Fint om dere kan verifisere at dere har tilgang til kontoen som heter omnibackup-prod.