### PR TITLE
Add API Gateway proxy module

### DIFF
--- a/modules/api-gateway-proxy/main.tf
+++ b/modules/api-gateway-proxy/main.tf
@@ -1,0 +1,62 @@
+data "aws_api_gateway_rest_api" "microservices_api" {
+  name = "${var.env}-microservices-api"
+}
+
+data "aws_api_gateway_resource" "services_resource" {
+  rest_api_id = data.aws_api_gateway_rest_api.microservices_api.id
+  path        = "/services"
+}
+
+resource "aws_api_gateway_resource" "microservice_resource" {
+  rest_api_id = data.aws_api_gateway_rest_api.microservices_api.id
+  parent_id   = data.aws_api_gateway_resource.services_resource.id
+  path_part   = var.appname
+}
+
+resource "aws_api_gateway_resource" "proxy_resource" {
+  rest_api_id = data.aws_api_gateway_rest_api.microservices_api.id
+  parent_id   = aws_api_gateway_resource.microservice_resource.id
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "proxy_method" {
+  rest_api_id   = data.aws_api_gateway_rest_api.microservices_api.id
+  resource_id   = aws_api_gateway_resource.proxy_resource.id
+  http_method   = "ANY"
+  authorization = "NONE"
+  request_parameters = {
+    "method.request.path.proxy" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "proxy_integration" {
+  rest_api_id             = data.aws_api_gateway_rest_api.microservices_api.id
+  resource_id             = aws_api_gateway_resource.proxy_resource.id
+  http_method             = aws_api_gateway_method.proxy_method.http_method
+  type                    = "HTTP_PROXY"
+  uri                     = "${var.destination_uri}/{proxy}"
+  integration_http_method = "ANY"
+
+  cache_key_parameters = ["method.request.path.proxy"]
+
+  timeout_milliseconds = 29000
+  request_parameters = {
+    "integration.request.path.proxy" = "method.request.path.proxy"
+  }
+}
+
+resource "aws_api_gateway_deployment" "prod_deployment" {
+  depends_on  = [aws_api_gateway_integration.proxy_integration]
+  rest_api_id = data.aws_api_gateway_rest_api.microservices_api.id
+  stage_name  = var.stage_name
+
+  triggers = {
+    redeployment = sha1(join(",", list(
+      jsonencode(aws_api_gateway_integration.proxy_integration)
+    )))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/api-gateway-proxy/vars.tf
+++ b/modules/api-gateway-proxy/vars.tf
@@ -1,0 +1,16 @@
+variable "env" {
+  type = string
+}
+
+variable "appname" {
+  type = string
+}
+
+variable "destination_uri" {
+  type = string
+}
+
+variable "stage_name" {
+  type    = string
+  default = "prod"
+}

--- a/modules/api-gateway-proxy/versions.tf
+++ b/modules/api-gateway-proxy/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Denne modulen lager en proxy integrasjon for en mikrotjeneste på en API Gateway. Selve API Gatewayen opprettes i web-platform.

Modulen forventer å finne en resource med navn `/services`, og legger så proxy integrasjonen i en sub-resource navngitt etter mikrotjenesten, eks `/services/booking/{proxy+}`